### PR TITLE
Upgrade `jwt-decode` to `4.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "20.14.4",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
-        "jwt-decode": "3.1.2",
+        "jwt-decode": "4.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "6.23.1",
@@ -13194,10 +13194,12 @@
       }
     },
     "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
-      "license": "MIT"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/node": "20.14.4",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "jwt-decode": "3.1.2",
+    "jwt-decode": "4.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "6.23.1",

--- a/src/components/RequireAuth.jsx
+++ b/src/components/RequireAuth.jsx
@@ -1,6 +1,6 @@
 import { useLocation, Navigate, Outlet } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
-import jwtDecode from "jwt-decode";
+import { jwtDecode } from "jwt-decode";
 
 function hasMatchingRole(allowedRoles, userRoles) {
     if (!allowedRoles || allowedRoles.length === 0) {


### PR DESCRIPTION
### Description

Upgrades the `jwt-decode` dependency to `4.0.0`, which breaks the default exported function `jwtDecode`.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
